### PR TITLE
Adding reference field from Places Details call.

### DIFF
--- a/examples/form.html
+++ b/examples/form.html
@@ -70,6 +70,9 @@
 
         <label>ID</label>
         <input name="id" type="text" value="">
+        
+        <label>Reference</label>
+        <input name="reference" type="text" value="">
 
         <label>URL</label>
         <input name="url" type="text" value="">


### PR DESCRIPTION
Because front-end data can be tampered with, this is rather important if the data is to be stored in the backend. A backend API request can be made to the Places Detail API using the reference and the rest of the data can be discarded, making the data safe for storage. I've deployed a solution that uses these fields sans-reference and now it's going to be really tricky to go find the reference for each. This should prevent people in the future from having the same head-ache.
