### PR TITLE
Add geocode:click event on the map

### DIFF
--- a/jquery.geocomplete.js
+++ b/jquery.geocomplete.js
@@ -108,6 +108,13 @@
         $(this.options.map)[0],
         this.options.mapOptions
       );
+
+      // add click event listener on the map
+      google.maps.event.addListener(
+        this.map,
+        'click',
+        $.proxy(this.mapClicked, this)
+      );
     },
 
     // Add a marker with the provided `markerOptions` but only
@@ -373,6 +380,10 @@
     // Fire the "geocode:dragged" event and pass the new position.
     markerDragged: function(event){
       this.trigger("geocode:dragged", event.latLng);
+    },
+
+    mapClicked: function(event) {
+        this.trigger("geocode:click", event.latLng);
     },
 
     // Restore the old position of the marker to the last now location.


### PR DESCRIPTION
Now you can subscribe to "geocode:click" event on the map. Like that:

``` javascript
$("#inputElement").geocomplete({
    map: "#mapCanvas",
    markerOptions: {
        draggable: true
    }
}).bind("geocode:click", function(event, latLng)) {
    // your code goes here...
});
```

I've found this functionality very useful, and your library 'very lacking' of it.

I had to implement position change on click event on the map. Here's how it's possible to achieve this:

``` javascript
.bind("geocode:click", function(event, latLng)) {
    var latitude = latLng.lat();
    var longitude = latLng.lng();
    $("#inputElement").geocomplete('marker').setPosition(latLng);
});
```
