### PR TITLE
Added the blur option.

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ $("#my_input").geocomplete({
 * `maxZoom` - The maximum zoom level to zoom in after a geocoding response. Default: `16`
 * `componentRestrictions` - Option for Google Places Autocomplete to restrict results by country. See the [docs](https://developers.google.com/maps/documentation/javascript/places#places_autocomplete)
 * `types` - An array containing one or more of the supported types for the places request. Default: `['geocode']` See the full list [here](http://code.google.com/apis/maps/documentation/javascript/places.html#place_search_requests).
+* `blur` - Defaults to `false`. When enabled it will trigger the geocoding request whenever the geofield is blured. (See jQuery `.blur()`)
 
 ## Events
 

--- a/examples/form.html
+++ b/examples/form.html
@@ -13,76 +13,76 @@
     </style>
   </head>
   <body>
-    
+
     <div class="map_canvas"></div>
-    
+
     <form>
       <input id="geocomplete" type="text" placeholder="Type in an address" value="Empire State Bldg" />
       <input id="find" type="button" value="find" />
-      
+
       <fieldset>
         <h3>Address-Details</h3>
-      
+
         <label>Name</label>
         <input name="name" type="text" value="">
-        
+
         <label>POI Name</label>
         <input name="point_of_interest" type="text" value="">
-        
+
         <label>Latitude</label>
         <input name="lat" type="text" value="">
-      
+
         <label>Longitude</label>
         <input name="lng" type="text" value="">
-      
+
         <label>Location</label>
         <input name="location" type="text" value="">
-      
+
         <label>Location Type</label>
         <input name="location_type" type="text" value="">
-      
+
         <label>Formatted Address</label>
         <input name="formatted_address" type="text" value="">
-      
+
         <label>Bounds</label>
         <input name="bounds" type="text" value="">
-      
+
         <label>Viewport</label>
         <input name="viewport" type="text" value="">
-      
+
         <label>Route</label>
         <input name="route" type="text" value="">
-      
+
         <label>Street Number</label>
         <input name="street_number" type="text" value="">
-      
+
         <label>Postal Code</label>
         <input name="postal_code" type="text" value="">
-      
+
         <label>Locality</label>
         <input name="locality" type="text" value="">
-      
+
         <label>Sub Locality</label>
         <input name="sublocality" type="text" value="">
-      
+
         <label>Country</label>
         <input name="country" type="text" value="">
 
         <label>Country Code</label>
         <input name="country_short" type="text" value="">
-      
+
         <label>State</label>
         <input name="administrative_area_level_1" type="text" value="">
 
         <label>ID</label>
         <input name="id" type="text" value="">
-        
+
         <label>Reference</label>
         <input name="reference" type="text" value="">
 
         <label>URL</label>
         <input name="url" type="text" value="">
-        
+
         <label>Website</label>
         <input name="website" type="text" value="">
       </fieldset>
@@ -90,23 +90,24 @@
 
     <script src="http://maps.googleapis.com/maps/api/js?sensor=false&amp;libraries=places"></script>
     <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.7.1/jquery.min.js"></script>
-    
+
     <script src="../jquery.geocomplete.js"></script>
-    
+
     <script>
       $(function(){
         $("#geocomplete").geocomplete({
           map: ".map_canvas",
           details: "form",
-          types: ["geocode", "establishment"]
+          types: ["geocode", "establishment"],
+          blur: true
         });
-        
-        $("#find").click(function(){
-          $("#geocomplete").trigger("geocode");
-        });
+
+        // $("#find").click(function(){
+        //   $("#geocomplete").trigger("geocode");
+        // });
       });
     </script>
-    
+
   </body>
 </html>
 

--- a/jquery.geocomplete.js
+++ b/jquery.geocomplete.js
@@ -51,7 +51,8 @@
     },
 
     maxZoom: 16,
-    types: ['geocode']
+    types: ['geocode'],
+    blur: false
   };
 
   // See: [Geocoding Types](https://developers.google.com/maps/documentation/geocoding/#Types)
@@ -177,6 +178,15 @@
       this.$input.bind("geocode", $.proxy(function(){
         this.find();
       }, this));
+
+      // Trigger find action when input element is blured out.
+      // (Usefull for typing partial location and tabing to the next field
+      // or clicking somewhere else.)
+      if (this.options.blur === true){
+        this.$input.blur($.proxy(function(){
+          this.find();
+        }, this));
+      }
     },
 
     // Prepare a given DOM structure to be populated when we got some data.


### PR DESCRIPTION
I added a new option called blur. When set to true, a geocoding request will be triggered whenever the input element is blurred. 

For example, if the user enters a partial location and then presses tab or clicks on the next field in a form. It also solves some specific instances where the form action is post and the trigger request when clicking submit does not fire before the form is posted.
