### PR TITLE
Fixed blur autocomplete. Follow-up keep result at text input after focusout.

### DIFF
--- a/jquery.geocomplete.js
+++ b/jquery.geocomplete.js
@@ -12,7 +12,7 @@
 // * https://github.com/ubilabs/geocomplete/
 // * by Martin Kleppe <kleppe@ubilabs.net>
 
-;(function($, window, document, undefined){
+(function($, window, document, undefined){
 
   // ## Options
   // The default options for this plugin.
@@ -282,7 +282,7 @@
 
       // Get the first suggestion's text.
       var $span1 = $(".pac-container .pac-item" + selected + ":first span:nth-child(2)").text();
-      var $span2 = $(".pac-container .pac-item" + selected + ":first span:last").text();
+      var $span2 = $(".pac-container .pac-item" + selected + ":first span:nth-child(3)").text();
 
       // Adds the additional information, if available.
       var firstResult = $span1;


### PR DESCRIPTION
This is a followup of #94, fixing some bugs found later (such as selecting using the mouse).
It better fixes #91
This same code also fixes #75
