### PR TITLE
Allow to select first available completion

### DIFF
--- a/jquery.geocomplete.js
+++ b/jquery.geocomplete.js
@@ -447,7 +447,7 @@
     placeChanged: function(){
       var place = this.autocomplete.getPlace();
 
-      if (!place.geometry){
+      if (!place || !place.geometry){
         if (this.options.autoselect) {
           // Automatically selects the highlighted item or the first item from the
           // suggestions list.


### PR DESCRIPTION
This small fix avoids exception if getPlace() call in placeChanged function returns undefined.
This allows to implement saner blur behaviour that instead of running geocode on inserted text selects the first list item. The "blur: true" behaviour is not usable, because the returned locations are usually completely wrong when country limitation is turned on.

Example:

```
$("#id_address").blur(function () {
   $(this).geocomplete("placeChanged");
}); 
```
