### PR TITLE
Don't trigger a geocode request if the address input is empty

### DIFF
--- a/jquery.geocomplete.js
+++ b/jquery.geocomplete.js
@@ -306,6 +306,10 @@
     // Requests details about a given location.
     // Additionally it will bias the requests to the provided bounds.
     geocode: function(request){
+      // Don't geocode if the requested address is empty
+      if (!request.address) {
+        return;
+      }
       if (this.options.bounds && !request.bounds){
         if (this.options.bounds === true){
           request.bounds = this.map && this.map.getBounds();


### PR DESCRIPTION
We had the problem that a geocode would be triggered even if the input was empty. We couldn't reliably tell from the result whether the address specified by the user was empty (which is ok) or just not specific enough, in which case we'd ask him to give a more specific address.