### PR TITLE
FIX ISSUE #235 (autocomplete not working when multiple instances)

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,19 @@
+# EditorConfig is awesome: http://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+charset = utf-8
+
+# 2 space indentation
+indent_style = space
+indent_size = 2
+
+[**.md]
+# trailing spaces have a meaning in markdown
+trim_trailing_whitespace = false

--- a/jquery.geocomplete.js
+++ b/jquery.geocomplete.js
@@ -125,14 +125,14 @@
         'click',
         $.proxy(this.mapClicked, this)
       );
- 
+
       // add dragend even listener on the map
       google.maps.event.addListener(
         this.map,
         'dragend',
         $.proxy(this.mapDragged, this)
       );
-      
+
       // add idle even listener on the map
       google.maps.event.addListener(
         this.map,
@@ -358,8 +358,8 @@
       }
 
       // Get the first suggestion's text.
-      var $span1 = $(".pac-container:last .pac-item" + selected + ":first span:nth-child(2)").text();
-      var $span2 = $(".pac-container:last .pac-item" + selected + ":first span:nth-child(3)").text();
+      var $span1 = $(".pac-container:visible .pac-item" + selected + ":first span:nth-child(2)").text();
+      var $span2 = $(".pac-container:visible .pac-item" + selected + ":first span:nth-child(3)").text();
 
       // Adds the additional information, if available.
       var firstResult = $span1;
@@ -506,7 +506,7 @@
     mapClicked: function(event) {
         this.trigger("geocode:click", event.latLng);
     },
-   
+
     // Fire the "geocode:mapdragged" event and pass the current position of the map center.
     mapDragged: function(event) {
       this.trigger("geocode:mapdragged", this.map.getCenter());


### PR DESCRIPTION
`autoselect` option does not work when multiple geocomplete components are presents on the same page.

This behaviour can easily be tested on the 'multiple_fields' page example when pressing ENTER : the text entered by the user is deleted and no result id found.

The correction use the fact that there is only one .pac-container (dropdown) _visible_ when a component has the focus and the user press ENTER.