### PR TITLE
Allow types:[] in options

### DIFF
--- a/jquery.geocomplete.js
+++ b/jquery.geocomplete.js
@@ -84,6 +84,12 @@
 
     this.options = $.extend(true, {}, defaults, options);
 
+    // This is a fix to allow types:[] not to be overridden by defaults
+    // so search results includes everything
+    if (options.types) {
+      this.options.types = options.types;
+    }
+    
     this.input = input;
     this.$input = $(input);
 


### PR DESCRIPTION
Allow types:[] in options, which was earlier getting overiden by defaults