### PR TITLE
Fix Google Places API URL in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Here is a list of basic uses:
 Make sure you include the Google Maps API with the Places Library before loading this plugin as described [here](https://developers.google.com/maps/documentation/javascript/places#loading_the_library).
 
 ````html
-<script src="http://maps.googleapis.com/maps/api/js?libraries=places&sensor=false"></script>
+<script src="http://maps.googleapis.com/maps/api/js?libraries=places"></script>
 <script src="jquery.geocomplete.js"></script>
 ```
 


### PR DESCRIPTION
From Google Places documentation: The sensor parameter is no longer
required for the Google Maps JavaScript API. It won't prevent the Google
Maps JavaScript API from working correctly, but we recommend that you
remove the sensor parameter from the script element.

Leaving this parameter in displays a Warning in the browser's console.

Source:
https://developers.google.com/maps/documentation/javascript/error-messages#sensor-not-required