### PR TITLE
Fixed 'types' option deprecated problem by calling autoComplete.setType

### DIFF
--- a/jquery.geocomplete.js
+++ b/jquery.geocomplete.js
@@ -192,6 +192,8 @@
         this.input, options
       );
 
+      this.autocomplete.setTypes(options.types);
+
       this.geocoder = new google.maps.Geocoder();
 
       // Bind autocomplete to map bounds but only if there is a map


### PR DESCRIPTION
Setting "types" option in geocomplete() is no longer working for me. In my case, I need to restrict the autocomplete list results to only cities.  After digging my around in Google places API I found that they have changed "types" to "type" and developer needs to call setTypes() explicitly on autoComplete object after initialization. 

A good code example would be Google official example of AutoComplete.
https://developers.google.com/places/web-service/autocomplete

There is no change in using geocomplete library. For example, in order to get only cities users could initialize geocomplete like below.
$("#inputAddress").geocomplete({
    types: ['(cities)']
});